### PR TITLE
Ignoring invalid dates

### DIFF
--- a/Sources/usdToEur/ExchangeRate/Parser.swift
+++ b/Sources/usdToEur/ExchangeRate/Parser.swift
@@ -23,7 +23,7 @@ struct ExchangeRateParser {
             throw ExchangeRateParserError.missingObservations
         }
 
-        return try observations.map(parseObservation)
+        return observations.compactMap({ try? parseObservation($0) })
     }
 
     private static func parseObservation(_ element: XMLElement) throws -> ExchangeRate {


### PR DESCRIPTION
The app is failing ever since the European Central Bank started returning exchange rates for November 2nd 2004. For some reason, the `DateFormatter` is unable to parse this date:

<img width="440" alt="Screenshot 2021-12-18 at 12 16 20" src="https://user-images.githubusercontent.com/2430631/146646226-41099ab8-46ae-4407-b74f-a71dde70c904.png">

